### PR TITLE
more reverting

### DIFF
--- a/database/admin.js
+++ b/database/admin.js
@@ -65,19 +65,6 @@ class QuoteAdmin {
       this.handleAddQuote();
     });
 
-    // Category dropdown change
-    const categorySelect = document.getElementById('quoteCategorySelect');
-    categorySelect?.addEventListener('change', (e) => {
-      const newCategoryInput = document.getElementById('newCategoryInput');
-      if (e.target.value === 'add_new') {
-        newCategoryInput.style.display = 'block';
-        newCategoryInput.required = true;
-      } else {
-        newCategoryInput.style.display = 'none';
-        newCategoryInput.required = false;
-      }
-    });
-
     // Search functionality
     const searchBtn = document.getElementById('searchBtn');
     const searchInput = document.getElementById('searchQuotes');
@@ -130,9 +117,6 @@ class QuoteAdmin {
 
     // Load content based on tab
     switch (tabName) {
-      case 'add':
-        this.populateAddCategoryDropdown();
-        break;
       case 'manage':
         this.loadQuotesList();
         break;
@@ -140,28 +124,6 @@ class QuoteAdmin {
         this.loadStats();
         break;
     }
-  }
-
-  /**
-   * Populate the category dropdown in the "Add Quote" tab
-   */
-  populateAddCategoryDropdown() {
-    const categorySelect = document.getElementById('quoteCategorySelect');
-    if (!categorySelect) return;
-
-    const categories = this.db.getAllCategories();
-    
-    // Clear existing options except the first two
-    while (categorySelect.options.length > 2) {
-      categorySelect.remove(2);
-    }
-
-    categories.forEach(category => {
-      const option = document.createElement('option');
-      option.value = category;
-      option.textContent = category;
-      categorySelect.appendChild(option);
-    });
   }
 
   /**
@@ -619,12 +581,12 @@ class QuoteAdmin {
     }
   }
 
-    /**
-     * Escape HTML to prevent XSS
-     */
-    escapeHtml(text) {
-      const div = document.createElement('div');
-      div.textContent = text;
-      return div.innerHTML;
-    }
+      /**
+       * Escape HTML to prevent XSS
+       */
+      escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+      }
   }

--- a/index.html
+++ b/index.html
@@ -92,29 +92,21 @@
               <label for="quoteTextInput">Quote Text:</label>
               <textarea id="quoteTextInput" required placeholder="Enter the quote text..."></textarea>
             </div>
-            <div class="form-row">
-              <div class="form-group">
-                <label for="quoteAuthorInput">Author:</label>
-                <input type="text" id="quoteAuthorInput" required placeholder="Enter the author name...">
-              </div>
-              <div class="form-group">
-                <label for="quoteCategorySelect">Category:</label>
-                <select id="quoteCategorySelect" required>
-                  <option value="" disabled selected>Select a category</option>
-                  <option value="add_new">-- Add New Category --</option>
-                </select>
-                <input type="text" id="newCategoryInput" placeholder="Enter new category name..." style="display: none; margin-top: 10px;">
-              </div>
+            <div class="form-group">
+              <label for="quoteAuthorInput">Author:</label>
+              <input type="text" id="quoteAuthorInput" required placeholder="Enter the author name...">
             </div>
             <div class="form-group">
-              <label for="quoteTagsInput">Tags (optional, comma-separated):</label>
-              <input type="text" id="quoteTagsInput" placeholder="e.g., motivation, life, success">
+              <label for="quoteCategoryInput">Category:</label>
+              <input type="text" id="quoteCategoryInput" required placeholder="Enter category...">
+            </div>
+            <div class="form-group">
+              <label for="quoteTagsInput">Tags (comma separated):</label>
+              <input type="text" id="quoteTagsInput" placeholder="motivation, success, life...">
             </div>
             <button type="submit" class="btn">Add Quote</button>
           </form>
-        </div>
-
-        <!-- Manage Quotes Tab -->
+        </div>        <!-- Manage Quotes Tab -->
         <div class="tab-content" id="manage-tab">
           <div class="search-container">
             <input type="text" id="searchQuotes" placeholder="Search quotes...">

--- a/styles.css
+++ b/styles.css
@@ -675,15 +675,6 @@ footer nav a {
   resize: vertical;
 }
 
-.form-row {
-  display: flex;
-  gap: 20px;
-}
-
-.form-row .form-group {
-  flex: 1;
-}
-
 
 .search-container {
   display: flex;


### PR DESCRIPTION
This pull request simplifies the quote category selection process in the admin interface by removing the category dropdown and associated logic, replacing it with a straightforward text input for category entry. It also cleans up related code and styling. The changes streamline the UI and reduce complexity in both the frontend and backend code.

**UI Simplification:**

* Replaced the category dropdown (`quoteCategorySelect`) and "add new category" input with a single text input (`quoteCategoryInput`) for entering categories directly in `index.html`. This removes the need for users to select or add categories via a dropdown.
* Removed the associated CSS for `.form-row` and its flex styling, since the dropdown and its layout are no longer needed.

**Codebase Cleanup:**

* Removed the event listener for category dropdown changes in `QuoteAdmin` class, as the dropdown and its functionality have been eliminated.
* Deleted the `populateAddCategoryDropdown` method from `QuoteAdmin`, which previously handled populating the dropdown with categories from the database.
* Updated tab logic in `QuoteAdmin` to remove the call to `populateAddCategoryDropdown` when loading the "Add Quote" tab, since the dropdown no longer exists.